### PR TITLE
Fix output for site url

### DIFF
--- a/vhost.php
+++ b/vhost.php
@@ -97,7 +97,7 @@ class VirtualHost
 
         echo $this->output;
 
-        echo "\nSite URL: " . $this->address . $this->server_path;
+        echo "\nSite URL: {$this->address}/{$this->server_name}";
         echo "\nPublic Directory: " . $this->document_root;
 
         echo "\nDoes the above look correct? (startover=n) [y/n]:";


### PR DESCRIPTION
The output before accepting the vhost was using the ServerPath instead of ServerName so it looked like so:

```
Site URL: 127.0.0.1ServerPath /unicorn
```

This fixes it to look like:

```
Site URL: 127.0.0.1/unicorn
```
